### PR TITLE
Add Thrive to charting, research & no-code decision support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ These services are valuable to discretionary and hybrid workflows even when they
 | 49 | **[CoinQuant](https://www.coinquant.ai/)** [48] | No-code, AI-assisted strategy builder and backtesting platform for market research and systematic experimentation. | Crypto; traditional markets; Research / automation | [Public API skills pack](https://www.coinquant.ai/documentation/public-api-skills-pack) · Py: — · Go: — · PHP: — | Free credits; public paid plans listed from **$12.99/week**. |
 | 50 | **[TradingCursor](https://www.tradingcursor.com/)** [49] | AI-assisted multi-signal research product for stocks, ETFs, forex, and crypto decision support. | Traditional markets; Forex / FX; crypto; Research | No public API identified · Py: — · Go: — · PHP: — | Free daily analysis; Pro is publicly listed at **$9.90/month**. |
 | 51 | **[LONA™](https://www.lona.agency/en)** [50] | No-code AI trading assistant for creating, backtesting, and optimizing trading ideas. | Traditional markets; Forex / FX; crypto; Research / automation | No public API identified · Py: — · Go: — · PHP: — | Free tier; Pro **$49/month**, Premium **$99/month**, Quant **$249/month**. |
+| | **[Thrive](https://thrive.fi/)** [137] | CEX perpetuals trading journal and market-intelligence workstation for active traders, with read-only exchange sync. | Crypto — derivatives; Research / automation | No public API identified · Py: — · Go: — · PHP: — | Public Pro plan is **$7** due today, then **$99/month** or **$999/year**; see [official pricing](https://thrive.fi/pricing). |
 
 ---
 
@@ -538,6 +539,7 @@ There is no universal "best" service. Start with the narrowest tool that satisfi
 [134] Awesome Quant — [GitHub](https://github.com/wilsonfreitas/awesome-quant)
 [135] SSRN — [Official site](https://www.ssrn.com/)
 [136] arXiv Quantitative Finance — [Official site](https://arxiv.org/archive/q-fin) · [API docs](https://arxiv.org/help/api/)
+[137] Thrive — [Official site](https://thrive.fi/) · [Documentation](https://thrive.fi/docs) · [Pricing](https://thrive.fi/pricing)
 ---
 
 ## License


### PR DESCRIPTION
## Summary
- Add **[Thrive](https://thrive.fi/)** to section 5 (charting, research & no-code decision support).
- Rank left blank for editorial assignment, per CONTRIBUTING.md.
- New reference [137] with official site, docs, and pricing.

## Why it belongs
Section 5 already includes research/workstation products without a general public trading API (TradingView, Koyfin, TradingCursor, LONA). Thrive is a CEX perpetuals trading journal and market-intelligence workstation. Exchange connections are read-only sync; live order routing is not the product.

Editorial criteria met (at least two):
- Distinctive specialization: CEX perps journal + market intel in one research loop (hypothesis → data → agent → paper practice → journal closure).
- Workflow relevance next to the existing no-code / research tools.

## Facts used (no invented traction)
- Brand: Thrive · company Thrive DeFi, LLC
- Site: https://thrive.fi · app: https://app.thrive.fi · docs: https://thrive.fi/docs · pricing: https://thrive.fi/pricing
- Public Pro plan: $7 due today, then $99/month or $999/year
- Not an exchange, bot, wallet, custodian, token, DEX, or investment adviser
- First-party submission as accomplish999

Thrive is not already listed (searched README for thrive / thrive.fi).